### PR TITLE
Add whitespace after comment characters

### DIFF
--- a/src/Edit.hs
+++ b/src/Edit.hs
@@ -890,7 +890,7 @@ commentLine' mvS = do
   now <- realToFrac <$> getPOSIXTime
   let (ls, (y,x), _, l, _, _, postX) = cursorContext s
       change | isPrefixOf "--" $ lText l = Just $ deleteChange (y,0) (y,2) [postX]
-             | otherwise = Just $ (insertChange (y,0) ["--"]) {cWhen = now}
+             | otherwise = Just $ (insertChange (y,0) ["-- "]) {cWhen = now}
   s' <- maybe (return s) (applyChange s) change
   putMVar mvS s'
 


### PR DESCRIPTION
I noticed that without a whitespace after `--` the feature #13  is not that usable :)